### PR TITLE
fix(build): resolve buildArgs from k8s secrets before docker build

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -42,12 +42,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.INFRASTRUCTURE_PAT }}
 
-      - name: Build and push Docker image
-        run: |
-          DEPLOYMENT_VERSION=${{ github.event.client_payload.version }} \
-          CONFIG_FILE="client/${{ github.event.client_payload.config_file }}" \
-          ./scripts/build.sh
-
       - name: Configure VPN
         uses: tailscale/github-action@v3
         with:
@@ -60,6 +54,12 @@ jobs:
           mkdir -p ~/.kube
           echo "${{ secrets.KUBECONFIG }}" > ~/.kube/config
           chmod 600 ~/.kube/config
+
+      - name: Build and push Docker image
+        run: |
+          DEPLOYMENT_VERSION=${{ github.event.client_payload.version }} \
+          CONFIG_FILE="client/${{ github.event.client_payload.config_file }}" \
+          ./scripts/build.sh
 
       - name: Deploy services using Helm
         run: |

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,7 +4,37 @@ set -euo pipefail
 CONFIG_FILE=${CONFIG_FILE:-"client/deployment.yaml"}
 DEPLOYMENT_VERSION=${DEPLOYMENT_VERSION:-latest}
 
+NAMESPACE=$(yq -r .namespace "$CONFIG_FILE")
 SERVICE_COUNT=$(yq '.services | length' "$CONFIG_FILE")
+
+resolve_build_arg() {
+  local svc_idx=$1
+  local arg_idx=$2
+
+  local arg_name
+  arg_name=$(yq -r ".services[$svc_idx].buildArgs[$arg_idx].name" "$CONFIG_FILE")
+
+  local inline_value
+  inline_value=$(yq -r ".services[$svc_idx].buildArgs[$arg_idx].value // \"\"" "$CONFIG_FILE")
+  if [ -n "$inline_value" ] && [ "$inline_value" != "null" ]; then
+    printf '%s=%s' "$arg_name" "$inline_value"
+    return 0
+  fi
+
+  local secret_name secret_key value
+  secret_name=$(yq -r ".services[$svc_idx].buildArgs[$arg_idx].valueFrom.secretKeyRef.name // \"\"" "$CONFIG_FILE")
+  secret_key=$(yq -r ".services[$svc_idx].buildArgs[$arg_idx].valueFrom.secretKeyRef.key // \"\"" "$CONFIG_FILE")
+  if [ -z "$secret_name" ] || [ -z "$secret_key" ]; then
+    echo "❌ buildArgs[$arg_idx] for service[$svc_idx] has neither value nor valueFrom.secretKeyRef" >&2
+    return 1
+  fi
+  value=$(kubectl -n "$NAMESPACE" get secret "$secret_name" -o jsonpath="{.data.$secret_key}" | base64 -d)
+  if [ -z "$value" ]; then
+    echo "❌ secret $NAMESPACE/$secret_name#$secret_key resolved to empty" >&2
+    return 1
+  fi
+  printf '%s=%s' "$arg_name" "$value"
+}
 
 for i in $(seq 0 $((SERVICE_COUNT - 1))); do
   if [[ $(yq -r ".services[$i].image" "$CONFIG_FILE") != ghcr.io/* ]]; then
@@ -16,6 +46,15 @@ for i in $(seq 0 $((SERVICE_COUNT - 1))); do
   SERVICE_CONTEXT="client/$(yq -r ".services[$i].context // \".\"" "$CONFIG_FILE")"
   DOCKERFILE_PATH="${SERVICE_CONTEXT}/$(yq -r ".services[$i].dockerfile // \"Dockerfile\"" "$CONFIG_FILE")"
 
+  build_arg_flags=()
+  BUILD_ARG_COUNT=$(yq -r ".services[$i].buildArgs | length // 0" "$CONFIG_FILE")
+  if [ "$BUILD_ARG_COUNT" != "null" ] && [ "$BUILD_ARG_COUNT" -gt 0 ]; then
+    for j in $(seq 0 $((BUILD_ARG_COUNT - 1))); do
+      pair=$(resolve_build_arg "$i" "$j")
+      build_arg_flags+=(--build-arg "$pair")
+    done
+  fi
+
 
   echo "🔨 Building $IMAGE_NAME:$DEPLOYMENT_VERSION"
 
@@ -23,10 +62,11 @@ for i in $(seq 0 $((SERVICE_COUNT - 1))); do
     -t ${IMAGE_NAME}:${DEPLOYMENT_VERSION} \
     -t ${IMAGE_NAME}:latest \
     -f ${DOCKERFILE_PATH} \
+    "${build_arg_flags[@]}" \
     ${SERVICE_CONTEXT}
 
   docker push ${IMAGE_NAME}:${DEPLOYMENT_VERSION}
   docker push ${IMAGE_NAME}:latest
-  
+
   echo "✅ Done building and pushing $IMAGE_NAME"
 done


### PR DESCRIPTION
## Diagnosis

The Expo web bundle for ma3ady (and any other app baking config into a static bundle) was shipping to production with placeholder URLs instead of real values. Root cause: `EXPO_PUBLIC_*` env vars are baked into the bundle at `docker build` time, but they weren't being passed to `docker build` at all — there was no mechanism in `scripts/build.sh` to read build args from the deployment manifest, and even if there had been, the build step ran before the cluster was reachable so it couldn't have pulled values from k8s Secrets.

## Changes

- **`scripts/build.sh`**: read `services[i].buildArgs[]` from the deployment manifest. Each entry supports either an inline `value:` string or a `valueFrom.secretKeyRef: { name, key }` reference, resolved via `kubectl get secret -n $NAMESPACE`. Resolved pairs are passed to `docker build --build-arg`.
- **`.github/workflows/deploy-app.yaml`**: move `Configure VPN` + `Configure Kubernetes` ahead of the build step so the `kubectl` call above can reach the cluster.

Services that don't declare `buildArgs` continue to build unchanged (the `build_arg_flags` array stays empty).

## Related

Unblocks markmorcos/ma3ady#23, which adds the `buildArgs` block to the ma3ady deployment manifest so the Expo web bundle gets real `EXPO_PUBLIC_*` values at build time.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEVXKtU73Ks5XqfZDNRUGj)_