### PR TITLE
fix(deploy-app): invoke build.sh/deploy.sh via bash to ignore exec bit

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -59,7 +59,7 @@ jobs:
         run: |
           DEPLOYMENT_VERSION=${{ github.event.client_payload.version }} \
           CONFIG_FILE="client/${{ github.event.client_payload.config_file }}" \
-          ./scripts/build.sh
+          bash scripts/build.sh
 
       - name: Deploy services using Helm
         run: |
@@ -67,4 +67,4 @@ jobs:
           DEPLOYMENT_TOKEN=${{ github.event.client_payload.token }} \
           DEPLOYMENT_VERSION=${{ github.event.client_payload.version }} \
           CONFIG_FILE="client/${{ github.event.client_payload.config_file }}" \
-          ./scripts/deploy.sh
+          bash scripts/deploy.sh


### PR DESCRIPTION
## Summary

Deploys are failing at the build step:

```
./scripts/build.sh: Permission denied
Error: Process completed with exit code 126.
```

Exit 126 = file found but not executable. PR #4 was merged via the GitHub Contents API (the Claude Code MCP `push_files` tool writes blobs as mode `100644`), which silently stripped the `+x` bit off `scripts/build.sh`. The workflow invokes `./scripts/build.sh` directly, so the next deploy errors immediately.

## Fix

Invoke the scripts via `bash scripts/build.sh` (and the same for `deploy.sh`) instead of `./scripts/...`. The executable bit becomes irrelevant, so future mode-stripping merges via the Contents API don't break deploys.

Cleaner than:
- tracking the `+x` bit in git (every uploader has to remember to preserve it), or
- `chmod +x` in every job (adds noise + has to be repeated per script).

## Test plan

- [ ] Merge.
- [ ] Re-trigger the failing `deploy-ma3ady` (workflow_dispatch the ma3ady-web deploy workflow) and confirm "Build and push Docker image" runs through.

https://claude.ai/code/session_01NhhuMj75jjBe4M7dse6Vkq

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhhuMj75jjBe4M7dse6Vkq)_