### PR TITLE
chore(deploy): cap helm release history at 3 revisions

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -167,6 +167,7 @@ main() {
     -f "$CONFIG_FILE"
     -n "$namespace"
     --create-namespace
+    --history-max=3
   )
 
   if [[ "$dry_run" == "true" ]]; then


### PR DESCRIPTION
## Summary
- Adds `--history-max=3` to the `helm upgrade --install` call in `scripts/deploy.sh` so Helm only retains the last 3 release revisions per release.
- Each Helm release revision is stored as a Kubernetes Secret containing the gzipped+base64 chart + values + rendered manifests; with the default (keep all), this recently bloated the k3s SQLite datastore from ~11 MB to 4.5 GB across 138 release Secrets. Capping at 3 keeps rollback usable while preventing recurrence.

## Changes
- `scripts/deploy.sh`: append `--history-max=3` to the existing `helm_args` array (single point of change — `deploy.sh` only has one helm release call site).
- File remains executable (`-rwxr-xr-x`).

## Verification
- `bash -n scripts/deploy.sh` — parses cleanly.
- `grep -nE 'helm[[:space:]]+(install|upgrade)' scripts/deploy.sh` — one match (line 164, `helm upgrade --install`).
- `grep -nE '(--history-max|HELM_FLAGS|helm_upgrade)' scripts/deploy.sh` — `--history-max=3` present at line 170 in the same args array.
- No cluster operations performed; static edit only.

## Test plan
- [ ] Confirm next deploy run logs include `--history-max=3` in the helm command.
- [ ] After a few deploys, verify `helm history <release> -n <ns>` shows at most 3 revisions and that release Secret count stays bounded.


---
_Generated by [Claude Code](https://claude.ai/code/session_014eXiAdQy3ehY2BjjArnf9L)_