### PR TITLE
Add Pi monitoring stack (Uptime Kuma) and bootstrap teardown script

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -18,6 +18,31 @@ curl -fsSL https://raw.githubusercontent.com/markmorcos/infrastructure/main/boot
 
 Re-run any time — every step is idempotent.
 
+## Teardown
+
+`down.sh` reverses `run.sh`. It reads the same `.env` and the same `INSTALL_*`
+toggles, then undoes each enabled phase in reverse order (services disabled,
+unit files / scripts / apt repos / keyrings removed). Idempotent and safe to
+re-run.
+
+```bash
+sudo FORCE=1 ./down.sh                       # tear down, KEEP all data
+sudo FORCE=1 PURGE_DATA=1 ./down.sh          # also delete DB / MinIO data dirs
+sudo FORCE=1 REMOVE_TAILSCALE=1 ./down.sh    # also leave the tailnet
+```
+
+Safety defaults:
+
+- **Data is kept** unless `PURGE_DATA=1` (then `POSTGRES_DATA` / `MONGO_DATA` /
+  `REDIS_DATA` / `MINIO_VOLUMES` are deleted).
+- **Tailscale is left in place** unless `REMOVE_TAILSCALE=1` — removing it would
+  drop a Tailscale-SSH session, so do that from a local console.
+- **k3s** is removed via its official uninstall script, which also clears
+  `/var/lib/rancher` (inherent to uninstalling, independent of `PURGE_DATA`).
+- Base packages (curl, jq, gnupg, …) are intentionally left installed.
+- Without `FORCE=1` the script prompts interactively, and refuses to run at all
+  when piped (no TTY).
+
 ## Setting up the Pi (server)
 
 ```ini
@@ -107,7 +132,8 @@ If it returns `16384`, add `kernel=kernel8.img` to `/boot/firmware/config.txt` a
 
 ## Files in this repo
 
-- `run.sh` — the one and only script; idempotent, safe to re-run
+- `run.sh` — the bootstrap; idempotent, safe to re-run
+- `down.sh` — reverses `run.sh`; idempotent. Keeps data unless `PURGE_DATA=1`
 - `.env.example` — copy + edit to `/etc/infrastructure/bootstrap/.env` on each host
 - `domains.conf` — list of CF zones and records to keep pointed at home IP
 - `README.md` — this file

--- a/bootstrap/down.sh
+++ b/bootstrap/down.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+#
+# infrastructure node teardown — reverses bootstrap/run.sh
+#
+# Mirrors run.sh: reads the same /etc/infrastructure/bootstrap/.env and the same
+# INSTALL_* toggles, then tears down each phase in REVERSE order. Each phase
+# only undoes what its toggle enabled. Idempotent and safe to re-run.
+#
+# Usage:
+#   sudo FORCE=1 ./down.sh                       # tear down, KEEP all data
+#   sudo FORCE=1 PURGE_DATA=1 ./down.sh          # also delete DB/MinIO data dirs
+#   sudo FORCE=1 REMOVE_TAILSCALE=1 ./down.sh    # also leave the tailnet (see warning)
+#
+# SAFETY:
+#   * Database/MinIO DATA IS KEPT by default. Set PURGE_DATA=1 to delete it.
+#   * Tailscale is LEFT IN PLACE by default — removing it would drop a
+#     Tailscale-SSH session. Set REMOVE_TAILSCALE=1 to remove it (ideally from
+#     a local console, not over SSH).
+#   * k3s is removed via its official uninstall script, which also deletes
+#     /var/lib/rancher regardless of PURGE_DATA (that's inherent to uninstalling).
+
+set -uo pipefail   # NOT -e: a teardown must push past already-absent items
+
+# === Constants ================================================================
+CONFIG_FILE="${CONFIG_FILE:-/etc/infrastructure/bootstrap/.env}"
+
+# === Logging ==================================================================
+log()  { printf '\033[1;34m[teardown]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[teardown]\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m[teardown]\033[0m %s\n' "$*" >&2; exit 1; }
+
+[[ $EUID -eq 0 ]] || die "Run as root (sudo)."
+command -v apt-get >/dev/null 2>&1 || die "This script targets Debian/Ubuntu."
+
+# === Load config ==============================================================
+if [[ -f "$CONFIG_FILE" ]]; then
+  log "Loading $CONFIG_FILE"
+  set -a; # shellcheck disable=SC1090
+  source "$CONFIG_FILE"; set +a
+fi
+
+# Toggles (same defaults as run.sh, so a config-driven teardown matches install)
+INSTALL_SYSCTL_FORWARD="${INSTALL_SYSCTL_FORWARD:-1}"
+INSTALL_TAILSCALE="${INSTALL_TAILSCALE:-1}"
+INSTALL_K3S="${INSTALL_K3S:-1}"
+INSTALL_CF_DDNS="${INSTALL_CF_DDNS:-1}"
+INSTALL_K3S_CLEANUP="${INSTALL_K3S_CLEANUP:-1}"
+INSTALL_MINIO="${INSTALL_MINIO:-0}"
+INSTALL_POSTGRES="${INSTALL_POSTGRES:-0}"
+INSTALL_MONGO="${INSTALL_MONGO:-0}"
+INSTALL_REDIS="${INSTALL_REDIS:-0}"
+INSTALL_DNSMASQ="${INSTALL_DNSMASQ:-0}"
+
+# Values we need to locate data dirs / units (mirror run.sh defaults)
+POSTGRES_VERSION="${POSTGRES_VERSION:-16}"
+POSTGRES_DATA="${POSTGRES_DATA:-/mnt/data/postgres}"
+MONGO_DATA="${MONGO_DATA:-/mnt/data/mongo}"
+REDIS_DATA="${REDIS_DATA:-/mnt/data/redis}"
+MINIO_VOLUMES="${MINIO_VOLUMES:-/mnt/data/minio}"
+DNSMASQ_DOMAIN="${DNSMASQ_DOMAIN:-morcos.lan}"
+
+# Teardown-only switches
+PURGE_DATA="${PURGE_DATA:-0}"
+REMOVE_TAILSCALE="${REMOVE_TAILSCALE:-0}"
+FORCE="${FORCE:-0}"
+
+# === Confirmation =============================================================
+if [[ "$FORCE" != "1" ]]; then
+  if [[ -t 0 ]]; then
+    warn "About to tear down infrastructure components on $(hostname)."
+    [[ "$PURGE_DATA"       == "1" ]] && warn "PURGE_DATA=1 — database/MinIO data WILL be deleted."
+    [[ "$REMOVE_TAILSCALE" == "1" ]] && warn "REMOVE_TAILSCALE=1 — this may drop your SSH session."
+    read -rp "Continue? [y/N] " ans
+    [[ "$ans" =~ ^[Yy]$ ]] || die "Aborted."
+  else
+    die "Refusing non-interactive teardown. Re-run with FORCE=1 to confirm."
+  fi
+fi
+
+# === Helpers ==================================================================
+stop_disable() { for u in "$@"; do systemctl disable --now "$u" >/dev/null 2>&1 || true; done; }
+rm_f()         { rm -f  "$@" 2>/dev/null || true; }
+rm_rf()        { rm -rf "$@" 2>/dev/null || true; }
+purge()        { DEBIAN_FRONTEND=noninteractive apt-get purge -y -qq "$@" >/dev/null 2>&1 || true; }
+
+# === Reverse Phase 10: dnsmasq ================================================
+if [[ "$INSTALL_DNSMASQ" == "1" ]]; then
+  log "Removing dnsmasq..."
+  stop_disable dnsmasq
+  purge dnsmasq
+  rm_f "/etc/dnsmasq.d/${DNSMASQ_DOMAIN}.conf"
+  rm_rf /etc/infrastructure/dnsmasq
+  warn "If this host was set as a Tailscale custom nameserver, remove it in the admin console."
+  warn "run.sh disabled systemd-resolved's stub listener; re-enable manually if you need it:"
+  warn "  sudo sed -i 's/^DNSStubListener=no/#DNSStubListener=/' /etc/systemd/resolved.conf && sudo systemctl restart systemd-resolved"
+fi
+
+# === Reverse Phase 9: Redis ===================================================
+if [[ "$INSTALL_REDIS" == "1" ]]; then
+  log "Removing Redis..."
+  stop_disable redis-server
+  purge redis redis-server redis-tools
+  rm_f /etc/redis/infrastructure.conf
+  rm_rf /etc/systemd/system/redis-server.service.d
+  rm_f /etc/apt/sources.list.d/redis.list /etc/apt/keyrings/redis.gpg
+  if [[ "$PURGE_DATA" == "1" ]]; then rm_rf "$REDIS_DATA"; warn "Deleted Redis data: $REDIS_DATA"; fi
+fi
+
+# === Reverse Phase 8: MongoDB =================================================
+if [[ "$INSTALL_MONGO" == "1" ]]; then
+  log "Removing MongoDB..."
+  stop_disable mongod
+  purge 'mongodb-org*' mongodb-mongosh
+  rm_f /etc/mongod.conf
+  rm_rf /etc/systemd/system/mongod.service.d
+  rm_f /etc/apt/sources.list.d/mongodb-org-*.list
+  rm_f /etc/apt/keyrings/mongodb-*.gpg
+  if [[ "$PURGE_DATA" == "1" ]]; then rm_rf "$MONGO_DATA"; warn "Deleted MongoDB data: $MONGO_DATA"; fi
+fi
+
+# === Reverse Phase 7: PostgreSQL ==============================================
+if [[ "$INSTALL_POSTGRES" == "1" ]]; then
+  log "Removing PostgreSQL ${POSTGRES_VERSION}..."
+  stop_disable "postgresql@${POSTGRES_VERSION}-main" postgresql
+  purge "postgresql-${POSTGRES_VERSION}" "postgresql-client-${POSTGRES_VERSION}" postgresql-common postgresql-client-common
+  rm_f /etc/apt/sources.list.d/pgdg.list /etc/apt/keyrings/pgdg.asc
+  rm_rf "/etc/postgresql/${POSTGRES_VERSION}"
+  if [[ "$PURGE_DATA" == "1" ]]; then rm_rf "$POSTGRES_DATA"; warn "Deleted PostgreSQL data: $POSTGRES_DATA"; fi
+fi
+
+# === Reverse Phase 6: MinIO ===================================================
+if [[ "$INSTALL_MINIO" == "1" ]]; then
+  log "Removing MinIO..."
+  stop_disable minio
+  rm_f /etc/systemd/system/minio.service
+  rm_f /usr/local/bin/minio
+  rm_f /etc/default/minio
+  if [[ "$PURGE_DATA" == "1" ]]; then rm_rf "$MINIO_VOLUMES"; warn "Deleted MinIO data: $MINIO_VOLUMES"; fi
+  getent passwd minio-user >/dev/null 2>&1 && userdel  minio-user 2>/dev/null || true
+  getent group  minio-user >/dev/null 2>&1 && groupdel minio-user 2>/dev/null || true
+fi
+
+# === Reverse Phase 5: k3s cleanup =============================================
+if [[ "$INSTALL_K3S_CLEANUP" == "1" ]]; then
+  log "Removing k3s cleanup timer..."
+  stop_disable k3s-cleanup.timer k3s-cleanup.service
+  rm_f /etc/systemd/system/k3s-cleanup.timer /etc/systemd/system/k3s-cleanup.service
+  rm_f /usr/local/lib/infrastructure/k3s-cleanup.sh
+fi
+
+# === Reverse Phase 4: Cloudflare DDNS =========================================
+if [[ "$INSTALL_CF_DDNS" == "1" ]]; then
+  log "Removing Cloudflare DDNS..."
+  stop_disable cloudflare-ddns.timer cloudflare-ddns.service
+  rm_f /etc/systemd/system/cloudflare-ddns.timer /etc/systemd/system/cloudflare-ddns.service
+  rm_f /usr/local/lib/infrastructure/cloudflare-ddns.sh
+  rm_f /etc/infrastructure/bootstrap/cloudflare-ddns.env
+fi
+
+systemctl daemon-reload 2>/dev/null || true
+
+# === Reverse Phase 3: k3s =====================================================
+if [[ "$INSTALL_K3S" == "1" ]]; then
+  log "Removing k3s (via official uninstall script)..."
+  if [[ -x /usr/local/bin/k3s-uninstall.sh ]]; then
+    /usr/local/bin/k3s-uninstall.sh || true
+  elif [[ -x /usr/local/bin/k3s-agent-uninstall.sh ]]; then
+    /usr/local/bin/k3s-agent-uninstall.sh || true
+  else
+    warn "No k3s uninstall script found — k3s may already be gone."
+  fi
+  rm_rf /etc/rancher/k3s
+fi
+
+# === Reverse Phase 2: Tailscale (guarded) =====================================
+if [[ "$INSTALL_TAILSCALE" == "1" && "$REMOVE_TAILSCALE" == "1" ]]; then
+  warn "Removing Tailscale — if you are connected via Tailscale SSH this WILL drop your session."
+  tailscale down   2>/dev/null || true
+  tailscale logout 2>/dev/null || true
+  purge tailscale
+  rm_rf /var/lib/tailscale
+elif [[ "$INSTALL_TAILSCALE" == "1" ]]; then
+  log "Leaving Tailscale in place (set REMOVE_TAILSCALE=1 to remove it)."
+fi
+
+# === Reverse Phase 1: sysctl IP forwarding ====================================
+if [[ "$INSTALL_SYSCTL_FORWARD" == "1" ]]; then
+  log "Removing IP-forwarding sysctl..."
+  rm_f /etc/sysctl.d/99-tailscale.conf
+  sysctl -w net.ipv4.ip_forward=0          >/dev/null 2>&1 || true
+  sysctl -w net.ipv6.conf.all.forwarding=0 >/dev/null 2>&1 || true
+fi
+
+# Note: Phase 0 base packages (curl, jq, gnupg, dnsutils, ca-certificates) are
+# intentionally left installed — they're generally useful and widely depended on.
+
+# === Done =====================================================================
+systemctl daemon-reload 2>/dev/null || true
+DEBIAN_FRONTEND=noninteractive apt-get autoremove -y -qq >/dev/null 2>&1 || true
+
+log "Teardown complete."
+[[ "$PURGE_DATA" == "1" ]] || log "Data dirs were KEPT (PURGE_DATA=0). Re-run with PURGE_DATA=1 to delete them."

--- a/monitoring/.env.example
+++ b/monitoring/.env.example
@@ -1,0 +1,3 @@
+# Cloudflare API token used by Caddy for the DNS-01 ACME challenge on morcos.tech.
+# Scope it narrowly: Zone -> DNS -> Edit, restricted to the morcos.tech zone.
+CF_API_TOKEN=

--- a/monitoring/Caddyfile
+++ b/monitoring/Caddyfile
@@ -1,0 +1,9 @@
+# Uptime Kuma dashboard, reachable only over the tailnet.
+# Real Let's Encrypt cert via DNS-01 (no public reachability required) — the
+# status.morcos.tech A record points at the Pi's Tailscale IP.
+status.morcos.tech {
+	reverse_proxy uptime-kuma:3001
+	tls {
+		dns cloudflare {env.CF_API_TOKEN}
+	}
+}

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,130 @@
+# monitoring
+
+Standalone uptime monitoring with [Uptime Kuma](https://github.com/louislam/uptime-kuma),
+fronted by [Caddy](https://caddyserver.com/) for TLS.
+
+## Where this runs (and why)
+
+This stack runs on the **Raspberry Pi via plain Docker Compose — _not_ in the
+k3s cluster.** A monitor must not depend on the thing it monitors: if Kuma
+lived inside the cluster on the M720q, a cluster/node outage would take the
+monitor down with it and you'd never get the alert. Running it on a separate
+Pi keeps it alive to report "M720q / cluster / DBs are down."
+
+This is why it's Docker Compose and not a Helm chart like the rest of the repo:
+Helm is for workloads _inside_ the cluster; this is deliberately _outside_ it.
+
+## Independence: no dependency on m720q's dnsmasq
+
+The split-DNS resolver (`:53` / dnsmasq) lives on m720q. If the Pi resolved
+names through it, the monitor would depend on the server again. It doesn't —
+every name the Pi needs is resolved without touching m720q:
+
+| What needs resolving                       | Route                                                        | Depends on m720q? |
+| ------------------------------------------ | ------------------------------------------------------------ | ----------------- |
+| Public sites (`*.morcos.tech`, etc.)       | public Cloudflare DNS                                        | No                |
+| Internal services (Postgres/Mongo/Redis)   | **Tailscale MagicDNS** — target `m720q.<tailnet>.ts.net`     | No (local netmap) |
+| The dashboard (`status.morcos.tech`)       | a **public** Cloudflare A record → the Pi's Tailscale IP     | No                |
+| The TLS cert (DNS-01 challenge)            | Caddy → Cloudflare API over the internet                     | No                |
+
+Two rules keep it that way:
+
+1. **Do not use `*.morcos.lan` names in the Pi's monitors.** Use Tailscale
+   names/IPs instead (e.g. `m720q.<tailnet>.ts.net:5432`). Then dnsmasq is
+   irrelevant to the Pi, and if m720q dies you get a clean "connection
+   refused" instead of a confusing DNS failure.
+2. **Publish `status.morcos.tech` in _public_ Cloudflare DNS**, pointing at the
+   Pi's `100.x` Tailscale IP — not in m720q's dnsmasq. It resolves everywhere
+   (a private IP in a public record is harmless) but is only _reachable_ from
+   inside the tailnet.
+
+## Prerequisites on the Pi
+
+- Ubuntu Server (24.04 LTS), joined to the tailnet (`tailscale up`).
+- Docker + Docker Compose plugin.
+- A Cloudflare API token scoped to **Zone → DNS → Edit** on the `morcos.tech`
+  zone (and nothing else).
+- **Pi 5 page-size gotcha:** a 16K-page kernel breaks Tailscale's Go binary.
+  Run `getconf PAGESIZE`; if it returns `16384`, add `kernel=kernel8.img` to
+  `/boot/firmware/config.txt` and reboot _before_ installing Tailscale.
+
+## Setup
+
+```bash
+# 1. DNS: add a PUBLIC Cloudflare A record
+#    status.morcos.tech  ->  <Pi Tailscale IP>   (e.g. 100.x.y.z)
+#    (proxy OFF / DNS-only; it's a private IP, reachable only on the tailnet)
+
+# 2. Secrets
+cp .env.example .env
+$EDITOR .env            # paste CF_API_TOKEN
+
+# 3. Bring it up (builds the Caddy image with the Cloudflare DNS plugin)
+docker compose up -d --build
+
+# 4. Open https://status.morcos.tech from any tailnet device and create the
+#    admin account immediately (first run is unauthenticated).
+```
+
+## Monitors to configure (in the Kuma UI)
+
+Group into **Public** and **Internal** for a clean board. Suggested: 60s
+interval, 2–3 retries before "down".
+
+### Public — HTTP(s), expect 2xx/3xx
+
+- `https://morcos.tech`
+- `https://games.morcos.tech`
+- `https://ma3ady.com`
+- `https://preview.ma3ady.com`
+- `https://app.ma3ady.com`
+- `https://preview-app.ma3ady.com`
+- `https://pile.bio`
+- `https://rdr.cx`
+- `https://eventlane.io`
+- `https://admin.eventlane.io`
+- `https://secrets.morcos.tech`
+- `https://stminaconnect.com`
+- `https://headlamp.morcos.tech`
+- `https://minio.morcos.tech`
+- `https://cdn.morcos.tech`
+- `https://api.eventlane.io` — **set accepted status codes `200-499`** (it
+  returns 403 on `/` but the backend is up).
+
+Add a keyword check on a page or two to catch "200 but broken."
+
+### Internal — TCP port, via Tailscale (NOT `*.morcos.lan`)
+
+Target the M720q's Tailscale name (or IP). Replace `<tailnet>` with your
+tailnet, or use the `100.x` address directly.
+
+- `m720q.<tailnet>.ts.net:5432` — PostgreSQL
+- `m720q.<tailnet>.ts.net:27017` — MongoDB
+- `m720q.<tailnet>.ts.net:6379` — Redis
+
+## Notifications
+
+Add a notifier in **Settings → Notifications** and attach it to every monitor.
+The alert path must leave your network so it doesn't depend on your own infra:
+
+- **Telegram** (easiest/free) — create a bot via @BotFather, get the chat ID.
+- **Email** via your existing Resend SMTP.
+- **ntfy** — push to your phone.
+
+## Backups
+
+All Kuma state (config + history) lives in the `kuma-data` volume (SQLite).
+Fold it into your off-site backup, e.g.:
+
+```bash
+docker run --rm -v monitoring_kuma-data:/data -v "$PWD":/backup alpine \
+  tar czf /backup/kuma-data-$(date +%F).tar.gz -C /data .
+```
+
+## Alternative exposure: `tailscale serve`
+
+If you'd rather drop Caddy + Cloudflare entirely, `tailscale serve --bg https /
+http://localhost:3001` gives `https://<pi>.<tailnet>.ts.net` with an auto real
+cert, fully independent of both m720q and Cloudflare (persists across reboots).
+You lose the `status.morcos.tech` name. To switch: publish Kuma's port locally
+and run `tailscale serve` instead of the Caddy service.

--- a/monitoring/caddy.Dockerfile
+++ b/monitoring/caddy.Dockerfile
@@ -1,0 +1,7 @@
+# The official caddy image ships no DNS providers, so build one in for the
+# Cloudflare DNS-01 ACME challenge. Builds on arm64 (Pi) and amd64 alike.
+FROM caddy:2-builder AS builder
+RUN xcaddy build --with github.com/caddy-dns/cloudflare
+
+FROM caddy:2
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,44 @@
+# Standalone monitoring host — runs on the Raspberry Pi, OUTSIDE the k3s cluster.
+# Deliberately independent of the M720q cluster so it can report the cluster down.
+# See README.md for the why and the DNS-independence design.
+services:
+  uptime-kuma:
+    image: louislam/uptime-kuma:1
+    container_name: uptime-kuma
+    restart: unless-stopped
+    volumes:
+      - kuma-data:/app/data
+    networks:
+      - monitoring
+    # No published ports: Caddy fronts it. Reach the UI at https://status.morcos.tech
+
+  caddy:
+    build:
+      context: .
+      dockerfile: caddy.Dockerfile
+    container_name: caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"          # ACME http redirect
+      - "443:443"        # https
+      - "443:443/udp"    # http/3
+    environment:
+      # Cloudflare token for the DNS-01 ACME challenge (Zone:DNS:Edit on morcos.tech).
+      - CF_API_TOKEN=${CF_API_TOKEN:?set CF_API_TOKEN in .env}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    networks:
+      - monitoring
+    depends_on:
+      - uptime-kuma
+
+networks:
+  monitoring:
+    driver: bridge
+
+volumes:
+  kuma-data:
+  caddy-data:
+  caddy-config:

--- a/monitoring/setup.sh
+++ b/monitoring/setup.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Bring a freshly-flashed Pi from zero to a running monitoring stack.
+# Idempotent: safe to re-run. Run from inside the monitoring/ directory.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# --- Pi 5 page-size guard ----------------------------------------------------
+# A 16K-page kernel breaks Tailscale's (and other) Go binaries.
+if [ "$(getconf PAGESIZE)" = "16384" ]; then
+  echo "ERROR: 16K page size detected. Add 'kernel=kernel8.img' to" >&2
+  echo "       /boot/firmware/config.txt and reboot before continuing." >&2
+  exit 1
+fi
+
+# --- Docker ------------------------------------------------------------------
+if ! command -v docker >/dev/null 2>&1; then
+  echo ">> Installing Docker..."
+  curl -fsSL https://get.docker.com | sh
+  sudo usermod -aG docker "$USER" || true
+  echo ">> Docker installed. You may need to log out/in for the group change."
+fi
+
+# --- Tailscale (warn only) ---------------------------------------------------
+if ! command -v tailscale >/dev/null 2>&1; then
+  echo "WARN: tailscale not found — join the tailnet or the dashboard won't be reachable." >&2
+elif ! tailscale status >/dev/null 2>&1; then
+  echo "WARN: tailscale is installed but not up. Run: sudo tailscale up" >&2
+fi
+
+# --- Secrets -----------------------------------------------------------------
+if [ ! -f .env ]; then
+  echo "ERROR: .env missing. Run: cp .env.example .env && \$EDITOR .env" >&2
+  exit 1
+fi
+if ! grep -q '^CF_API_TOKEN=.\+' .env; then
+  echo "ERROR: CF_API_TOKEN is empty in .env." >&2
+  exit 1
+fi
+
+# --- Bring it up -------------------------------------------------------------
+echo ">> Starting monitoring stack..."
+docker compose up -d --build
+
+pi_ip="$(tailscale ip -4 2>/dev/null || echo '<Pi Tailscale IP>')"
+echo ">> Done."
+echo ">> Ensure a PUBLIC Cloudflare A record exists: status.morcos.tech -> ${pi_ip}"
+echo ">> Then open https://status.morcos.tech from any tailnet device."


### PR DESCRIPTION
## Summary

Two additions:

### `monitoring/` — standalone Uptime Kuma host
Runs Uptime Kuma + Caddy via Docker Compose on the Raspberry Pi, deliberately
**outside** the k3s cluster so the monitor stays independent of what it watches.

- Caddy terminates TLS for `status.morcos.tech` using a Let's Encrypt **DNS-01**
  cert (Cloudflare), so the endpoint needs no public reachability — it resolves
  only on the tailnet but still gets a valid cert.
- Resolution and internal monitor targets lean on **public DNS + Tailscale
  MagicDNS** rather than m720q's dnsmasq, so the cluster's DNS being down can't
  blind the monitor.
- `setup.sh` takes a freshly-flashed Pi from zero to running (page-size guard →
  Docker install → `.env` validation → `compose up`).
- README documents the design, setup steps, and the monitor inventory
  (public `*.morcos.tech` HTTP checks + internal DBs via Tailscale TCP checks).

Files: `docker-compose.yml`, `Caddyfile`, `caddy.Dockerfile`, `.env.example`,
`setup.sh`, `README.md`.

### `bootstrap/down.sh` — teardown that reverses `run.sh`
Reads the same `.env` and `INSTALL_*` toggles, undoes each enabled phase in
reverse order (services disabled; units/scripts/apt repos/keyrings removed).

Safety defaults:
- **Data kept** unless `PURGE_DATA=1`.
- **Tailscale left in place** unless `REMOVE_TAILSCALE=1` (removing it would drop
  a Tailscale-SSH session).
- **k3s** removed via its official uninstall scripts.
- Refuses to run non-interactively without `FORCE=1`.

README's "Files in this repo" + a new Teardown section updated accordingly.

## Notes / follow-ups
- Public hostname list in the monitoring README is a best-effort reconstruction —
  worth a sanity check (`headlamp`/`minio`/`cdn`).
- `setup.sh`/`down.sh` land as mode `644` via the API; run as `bash <script>` or
  `chmod +x` first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CrswgzJzvPQrKXwAhekCix)_