### PR TITLE
feat(chart): support resources, probes, terminationGracePeriodSeconds (v0.6.0)

### DIFF
--- a/charts/infrastructure/Chart.yaml
+++ b/charts/infrastructure/Chart.yaml
@@ -2,6 +2,6 @@ name: infrastructure
 description: Reusable Helm chart for app services
 type: application
 apiVersion: v2
-version: 0.5.0
+version: 0.6.0
 appVersion: 1.0.0
 icon: https://avatars.githubusercontent.com/u/7705547?s=48&v=4

--- a/charts/infrastructure/templates/services.yaml
+++ b/charts/infrastructure/templates/services.yaml
@@ -26,6 +26,9 @@ spec:
         app: {{ $resourceName }}
         build-timestamp: '{{ now | date "20060102150405" }}'
     spec:
+{{- if .terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
+{{- end }}
 {{- if .volumes }}
       volumes:
 {{- range .volumes }}
@@ -66,6 +69,22 @@ spec:
               readOnly: {{ .readOnly }}
 {{- end }}
 {{- end }}
+{{- end }}
+{{- if .resources }}
+          resources:
+{{ toYaml .resources | indent 12 }}
+{{- end }}
+{{- if .startupProbe }}
+          startupProbe:
+{{ toYaml .startupProbe | indent 12 }}
+{{- end }}
+{{- if .livenessProbe }}
+          livenessProbe:
+{{ toYaml .livenessProbe | indent 12 }}
+{{- end }}
+{{- if .readinessProbe }}
+          readinessProbe:
+{{ toYaml .readinessProbe | indent 12 }}
 {{- end }}
 
 {{- if $ports }}

--- a/charts/infrastructure/values.schema.json
+++ b/charts/infrastructure/values.schema.json
@@ -2,6 +2,60 @@
   "$schema": "https://json-schema.org/draft-07/schema",
   "type": "object",
   "required": ["version", "project", "services"],
+  "definitions": {
+    "probe": {
+      "type": "object",
+      "description": "Kubernetes probe (startup/liveness/readiness)",
+      "properties": {
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": { "type": "string" },
+            "port": { "type": ["integer", "string"] },
+            "scheme": { "type": "string", "enum": ["HTTP", "HTTPS"] },
+            "host": { "type": "string" },
+            "httpHeaders": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["name", "value"],
+                "properties": {
+                  "name": { "type": "string" },
+                  "value": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "tcpSocket": {
+          "type": "object",
+          "properties": {
+            "port": { "type": ["integer", "string"] },
+            "host": { "type": "string" }
+          }
+        },
+        "exec": {
+          "type": "object",
+          "properties": {
+            "command": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "grpc": {
+          "type": "object",
+          "properties": {
+            "port": { "type": "integer" },
+            "service": { "type": "string" }
+          }
+        },
+        "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+        "periodSeconds": { "type": "integer", "minimum": 1 },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "successThreshold": { "type": "integer", "minimum": 1 },
+        "failureThreshold": { "type": "integer", "minimum": 1 },
+        "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 }
+      }
+    }
+  },
   "properties": {
     "version": {
       "type": "string",
@@ -82,6 +136,34 @@
             "default": 1,
             "description": "Number of deployment replicas"
           },
+          "terminationGracePeriodSeconds": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Grace period before SIGKILL during pod termination"
+          },
+          "resources": {
+            "type": "object",
+            "description": "Container resource requests and limits",
+            "properties": {
+              "requests": {
+                "type": "object",
+                "properties": {
+                  "cpu": { "type": ["string", "number"] },
+                  "memory": { "type": "string" }
+                }
+              },
+              "limits": {
+                "type": "object",
+                "properties": {
+                  "cpu": { "type": ["string", "number"] },
+                  "memory": { "type": "string" }
+                }
+              }
+            }
+          },
+          "startupProbe": { "$ref": "#/definitions/probe" },
+          "livenessProbe": { "$ref": "#/definitions/probe" },
+          "readinessProbe": { "$ref": "#/definitions/probe" },
           "context": {
             "type": "string",
             "description": "Optional override for the Docker build context"


### PR DESCRIPTION
## Summary

Extends the reusable `infrastructure` chart so service value files can set Kubernetes-native hardening fields without further chart changes.

- Adds passthroughs on the Deployment container: `resources`, `startupProbe`, `livenessProbe`, `readinessProbe`
- Adds `terminationGracePeriodSeconds` on the pod spec
- `values.schema.json` extended with matching definitions (shared `probe` ref)
- Chart version `0.5.0` → `0.6.0`

## Why

Eventlane API pods are `BestEffort` with no probes and no JVM heap cap, producing intermittent 48s timeouts and exit-255 restarts (likely Full GC stalls on an unbounded heap). Fixing this requires per-app `resources` and probes — but the current chart template silently drops those fields. This PR unblocks that work for eventlane and any other app that uses the chart.

## Compatibility

All new fields are optional. Verified with `helm template` that existing value files (eg. with no `resources` or probes) still render identically — only the new conditional blocks appear when the corresponding values are set.

## Rollout order

Merge this PR first so `publish-charts.yaml` pushes `0.6.0` to OCI. The eventlane PR (which pins `version: 0.6.0`) depends on it.

## Test plan

- [ ] `publish-charts.yaml` succeeds and `oci://ghcr.io/markmorcos/infrastructure:0.6.0` is published
- [ ] `helm template` of an existing value file (eg. `infrastructure/admin/deployment.yaml`) is byte-identical to the 0.5.0 render

https://claude.ai/code/session_01XVHf6LBGjucaAtwbuZnToj

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVHf6LBGjucaAtwbuZnToj)_