### PR TITLE
Add deploy-naharda-api and deploy-naharda-web dispatch types

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -9,6 +9,8 @@ on:
       - deploy-games
       - deploy-infrastructure-admin
       - deploy-ma3ady
+      - deploy-naharda-api
+      - deploy-naharda-web
       - deploy-portfolio
       - deploy-pile
       - deploy-scrum-poker


### PR DESCRIPTION
Registers the two Naharda services with the `deploy-app` workflow's `repository_dispatch` types, so deploy events sent from `markmorcos/naharda` are accepted (per the Naharda constitution §11).

- `deploy-naharda-api`
- `deploy-naharda-web` (added now so the dashboard deploy works when `web/` lands)

The client side in `markmorcos/naharda` (`.github/workflows/deploy-api.yaml`) sends the standard `client_payload` — `{repository, token, version, config_file}` — matching the eventlane pattern this workflow already consumes. No workflow logic changes; only the accepted dispatch type list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)