### PR TITLE
Make ingress www host opt-in

### DIFF
--- a/charts/infrastructure/Chart.yaml
+++ b/charts/infrastructure/Chart.yaml
@@ -2,6 +2,6 @@ name: infrastructure
 description: Reusable Helm chart for app services
 type: application
 apiVersion: v2
-version: 0.6.0
+version: 0.6.1
 appVersion: 1.0.0
 icon: https://avatars.githubusercontent.com/u/7705547?s=48&v=4

--- a/charts/infrastructure/templates/services.yaml
+++ b/charts/infrastructure/templates/services.yaml
@@ -115,14 +115,18 @@ metadata:
     cert-manager.io/cluster-issuer: "infrastructure-issuer"
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+{{- if .ingress.www }}
     nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
+{{- end }}
     nginx.ingress.kubernetes.io/use-forwarded-headers: "true"
 spec:
   ingressClassName: nginx
   tls:
     - hosts:
         - {{ .ingress.host }}
+{{- if .ingress.www }}
         - www.{{ .ingress.host }}
+{{- end }}
       secretName: infrastructure-tls
   rules:
     - host: {{ .ingress.host }}

--- a/charts/infrastructure/values.schema.json
+++ b/charts/infrastructure/values.schema.json
@@ -205,6 +205,11 @@
             "required": ["host", "path", "pathType"],
             "properties": {
               "host": { "type": "string", "description": "Ingress hostname" },
+              "www": {
+                "type": "boolean",
+                "default": false,
+                "description": "Add a www.<host> TLS SAN and enable the from-to-www redirect. Only enable when a www DNS record exists for the host, otherwise the HTTP-01 challenge for www.<host> will fail."
+              },
               "path": {
                 "type": "string",
                 "description": "Ingress path for this service"


### PR DESCRIPTION
## Why

Opening `naharda.com` on a fresh machine shows `NET::ERR_CERT_AUTHORITY_INVALID` — nginx is serving its default self-signed fallback cert instead of the real Let's Encrypt one.

Root cause: the ingress template unconditionally added a `www.<host>` SAN to every service's TLS cert (and enabled `from-to-www-redirect`). The `naharda` namespace runs three services that share the single `infrastructure-tls` secret — `web` (`naharda.com`), `api` (`api.naharda.com`), `analytics` (`analytics.naharda.com`). The auto-added `www.api.naharda.com` / `www.analytics.naharda.com` names have no DNS records, so their HTTP-01 challenges can never be solved. That fails the shared certificate, so no valid cert is ever issued and nginx falls back to the fake cert for every host, including `naharda.com`.

## What

- `templates/services.yaml`: gate the `www.<host>` TLS SAN **and** the `from-to-www-redirect` annotation behind a new optional `ingress.www` flag (default off). The TLS secret name is unchanged (`infrastructure-tls`).
- `values.schema.json`: document the optional `ingress.www` boolean.

Hosts that genuinely have a `www` record opt in with `ingress.www: true` (see the companion change in `markmorcos/naharda` where `web` opts in).

## Notes / follow-ups

- **Deploy-time change.** Services must be redeployed to pick up the new ingress manifests.
- **Existing poisoned secret.** If the warning persists after redeploy, delete `infrastructure-tls` in the `naharda` namespace so cert-manager re-issues: `kubectl -n naharda delete secret infrastructure-tls`.
- **Other projects share this template.** Since `www` now defaults off, any service that relied on the automatic `www` SAN will drop it on its *next* deploy until `www: true` is added to its config. Existing deployments are untouched until redeployed.
- The shared `infrastructure-tls` secret across three differing hosts in one namespace is kept per request; removing the non-resolving www SANs should let the cert issue, but a single aggregated cert (or per-service secrets) would be more robust long-term.

https://claude.ai/code/session_01MJEANmMMyeERiiY99Jybq8

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJEANmMMyeERiiY99Jybq8)_