### PR TITLE
Derive ingress TLS secret name per service

### DIFF
--- a/charts/infrastructure/Chart.yaml
+++ b/charts/infrastructure/Chart.yaml
@@ -2,6 +2,6 @@ name: infrastructure
 description: Reusable Helm chart for app services
 type: application
 apiVersion: v2
-version: 0.6.1
+version: 0.6.2
 appVersion: 1.0.0
 icon: https://avatars.githubusercontent.com/u/7705547?s=48&v=4

--- a/charts/infrastructure/templates/services.yaml
+++ b/charts/infrastructure/templates/services.yaml
@@ -127,7 +127,7 @@ spec:
 {{- if .ingress.www }}
         - www.{{ .ingress.host }}
 {{- end }}
-      secretName: infrastructure-tls
+      secretName: {{ .ingress.tlsSecret | default (printf "%s-tls" $resourceName) }}
   rules:
     - host: {{ .ingress.host }}
       http:

--- a/charts/infrastructure/values.schema.json
+++ b/charts/infrastructure/values.schema.json
@@ -210,6 +210,10 @@
                 "default": false,
                 "description": "Add a www.<host> TLS SAN and enable the from-to-www redirect. Only enable when a www DNS record exists for the host, otherwise the HTTP-01 challenge for www.<host> will fail."
               },
+              "tlsSecret": {
+                "type": "string",
+                "description": "Override the TLS secret name. Defaults to <namespace>-<service>-tls so each ingress gets its own certificate. Set this to a shared value only when several services intentionally serve the same host/cert."
+              },
               "path": {
                 "type": "string",
                 "description": "Ingress path for this service"


### PR DESCRIPTION
## Why

A single hardcoded `secretName: infrastructure-tls` on every ingress only works when a namespace has one ingress. The moment a namespace runs multiple services (naharda = web + api + analytics), all their ingresses point at the same secret with different hosts, cert-manager flaps the cert between them, and it never issues a valid cert for any host — which is what produced the `naharda.com` cert warnings.

## What

Default the ingress TLS secret to **`<namespace>-<service>-tls`** so every ingress gets its own independent certificate — in any namespace, single- or multi-service — with no per-project manifests to maintain:

```yaml
secretName: {{ .ingress.tlsSecret | default (printf "%s-tls" $resourceName) }}
```

- New optional `ingress.tlsSecret` override for the rare case where several services intentionally share one cert (e.g. path-based routing on the same host).
- Keeps the existing `cluster-issuer` annotation and the `www` opt-in.
- `Chart.yaml` bumped `0.6.1 → 0.6.2`; `values.schema.json` documents `tlsSecret`.

## Scalability / rollout

This is the zero-touch pattern for **every future project**: deploy a service with an ingress and it provisions its own cert automatically.

Rollout is gradual and safe because deploys pin the chart version per project (`helm --version <deployment.yaml version>`). Existing projects keep their current pinned chart and their `infrastructure-tls` secret until they individually bump — no mass re-issuance. When a project does adopt it, its ingress points at a new (initially empty) secret for a few seconds until cert-manager fills it: a one-time blip.

## After merge

- naharda companion PR pins web/api/analytics to `0.6.2`, giving `naharda-web-tls` / `naharda-api-tls` / `naharda-analytics-tls`.
- One-time cleanup once the new secrets are issued: `kubectl -n naharda delete certificate infrastructure-tls` (+ its empty secret) — the old colliding shim cert is no longer referenced.

https://claude.ai/code/session_01MJEANmMMyeERiiY99Jybq8

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJEANmMMyeERiiY99Jybq8)_