### PR TITLE
experimentation: rename seeded project datebloom → datewithmark

### DIFF
--- a/experimentation/README.md
+++ b/experimentation/README.md
@@ -5,8 +5,8 @@ multi-environment, typed flags with percentage rollout, and n-way (A/B, A/B/C, �
 experiments with frequentist results. One Go binary over Postgres, with a
 server-rendered admin UI and an SDK API for clients.
 
-The Datebloom ([datewithmark.com](https://datewithmark.com)) Sunset/Midnight/Linen
-test is just a **seeded example project** here — nothing is hard-coded to it.
+The Date with Mark ([datewithmark.com](https://datewithmark.com)) Sunset/Midnight/Linen
+test is just a **seeded example project** (`datewithmark`) here — nothing is hard-coded to it.
 
 | | |
 | --- | --- |
@@ -38,7 +38,7 @@ Clients authenticate with an **SDK key**, not the admin token.
 One payload: every evaluated flag + a variant assignment per running experiment.
 ```json
 {
-  "project": "datebloom",
+  "project": "datewithmark",
   "environment": "production",
   "features": { "new_booking_flow": true, "cta_label": "Ask out" },
   "experiments": { "date_flow_variant": { "variant": "midnight" } }
@@ -89,7 +89,7 @@ helm-installs `charts/infrastructure` from [`deployment.yaml`](./deployment.yaml
 - `experimentation-secrets` with key `ADMIN_TOKEN` (e.g. `openssl rand -hex 32`).
 - Cloudflare CNAME `experimentation` → the DDNS anchor.
 
-On first boot the `datebloom` project + `date_flow_variant` experiment are seeded
+On first boot the `datewithmark` project + `date_flow_variant` experiment are seeded
 and the production SDK key is logged.
 
 ## Develop / test

--- a/experimentation/seed.go
+++ b/experimentation/seed.go
@@ -6,11 +6,11 @@ import (
 	"log"
 )
 
-// seed creates the example Datebloom project (the datewithmark.com
+// seed creates the example datewithmark project (the datewithmark.com
 // Sunset/Midnight/Linen experiment) on first boot, so there is something to look
 // at. It is idempotent: it does nothing once the project exists.
 func (s *Server) seed(ctx context.Context) error {
-	_, err := s.store.GetProject(ctx, "datebloom")
+	_, err := s.store.GetProject(ctx, "datewithmark")
 	if err == nil {
 		return nil
 	}
@@ -18,7 +18,7 @@ func (s *Server) seed(ctx context.Context) error {
 		return err
 	}
 
-	p, _, sdkKey, err := s.provisionProject(ctx, "datebloom", "Datebloom")
+	p, _, sdkKey, err := s.provisionProject(ctx, "datewithmark", "Date with Mark")
 	if err != nil {
 		return err
 	}
@@ -38,6 +38,6 @@ func (s *Server) seed(ctx context.Context) error {
 	if _, err := s.store.CreateExperiment(ctx, exp); err != nil {
 		return err
 	}
-	log.Printf("seeded datebloom project; production SDK key: %s", sdkKey)
+	log.Printf("seeded datewithmark project; production SDK key: %s", sdkKey)
 	return nil
 }


### PR DESCRIPTION
Follow-up to #12 (already merged). `Datebloom` was the handoff/Figma working name; the live product is **datewithmark.com**, so the seeded example project is now `datewithmark` (display name "Date with Mark").

- `seed.go`: project key/name + existence check + log line.
- `README.md`: config example and deploy notes.

The `date_flow_variant` experiment and all platform behaviour are unchanged. Single commit on top of current `main`; `go build` + `go test` pass.

> If the service already booted and seeded `datebloom`, the new boot seeds `datewithmark` alongside it — remove the old one with `DELETE FROM projects WHERE key='datebloom';` (cascades).

https://claude.ai/code/session_01HgVsiZ6Yg3VRpYYto8sY9r

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgVsiZ6Yg3VRpYYto8sY9r)_