### PR TITLE
experimentation: full update/delete (CRUD) for every resource, with error feedback + e2e tests

### DIFF
--- a/experimentation/README.md
+++ b/experimentation/README.md
@@ -107,6 +107,14 @@ and the production SDK key is logged.
 
 ```bash
 cd experimentation
-go test ./...          # assignment, rollout, flag eval, z-test, form parsing, auth
+go test ./...                 # unit: assignment, rollout, flag eval, z-test, forms, auth, templates, routes
+go test -tags e2e ./...       # end-to-end: full CRUD + SDK happy path against a real Postgres
 DATABASE_URL=postgres://localhost/exp?sslmode=disable ADMIN_TOKEN=dev PORT=8090 go run .
 ```
+
+The `e2e` suite boots a throwaway Postgres itself (locating the installed
+`initdb`/`postgres`; dropping to the `postgres` system user when run as root) and
+drives the admin JSON API, the server-rendered UI forms and the public SDK
+endpoints through create → use → update → delete for every resource. It skips
+when no Postgres binaries are found; point it at an existing database instead
+with `TEST_DATABASE_URL=postgres://… go test -tags e2e ./...`.

--- a/experimentation/e2e_harness_test.go
+++ b/experimentation/e2e_harness_test.go
@@ -1,0 +1,180 @@
+//go:build e2e
+
+package main
+
+// A self-booting Postgres harness for the end-to-end suite. It locates the
+// installed initdb/postgres binaries and spins up a throwaway cluster in a temp
+// dir on a random port, then tears it down. When the suite runs as root (where
+// postgres refuses to start) it drops to the `postgres` system user for both
+// initdb and the server. If no binaries are available the whole suite skips.
+//
+// Run with:  go test -tags e2e ./...
+// Override with an external database:  TEST_DATABASE_URL=postgres://... go test -tags e2e ./...
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const testAdminToken = "e2e-admin-token"
+
+// testDSN is the connection string every e2e test dials. Empty means "skip".
+var testDSN string
+
+func TestMain(m *testing.M) {
+	var stop func()
+	if dsn := os.Getenv("TEST_DATABASE_URL"); dsn != "" {
+		testDSN = dsn
+	} else if pg, err := startEmbeddedPostgres(); err != nil {
+		fmt.Fprintf(os.Stderr, "e2e: postgres unavailable, tests will skip: %v\n", err)
+	} else {
+		testDSN, stop = pg.dsn, pg.stop
+	}
+	code := m.Run()
+	if stop != nil {
+		stop()
+	}
+	os.Exit(code)
+}
+
+type embeddedPG struct {
+	dsn  string
+	cmd  *exec.Cmd
+	base string
+}
+
+// findPGBin resolves a Postgres binary from PATH or the usual Debian/Ubuntu and
+// source install locations.
+func findPGBin(name string) (string, error) {
+	if p, err := exec.LookPath(name); err == nil {
+		return p, nil
+	}
+	for _, glob := range []string{
+		"/usr/lib/postgresql/*/bin/" + name,
+		"/usr/local/pgsql/bin/" + name,
+		"/opt/homebrew/opt/postgresql*/bin/" + name,
+	} {
+		if m, _ := filepath.Glob(glob); len(m) > 0 {
+			return m[len(m)-1], nil // highest version sorts last
+		}
+	}
+	return "", fmt.Errorf("%q not found on PATH or known install dirs", name)
+}
+
+func freePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+func startEmbeddedPostgres() (*embeddedPG, error) {
+	initdb, err := findPGBin("initdb")
+	if err != nil {
+		return nil, err
+	}
+	postgresBin, err := findPGBin("postgres")
+	if err != nil {
+		return nil, err
+	}
+
+	base, err := os.MkdirTemp("", "exp-e2e-")
+	if err != nil {
+		return nil, err
+	}
+	data := filepath.Join(base, "data")
+
+	// postgres refuses to run as root; drop to the postgres system user.
+	var cred *syscall.Credential
+	if os.Geteuid() == 0 {
+		u, err := user.Lookup("postgres")
+		if err != nil {
+			os.RemoveAll(base)
+			return nil, fmt.Errorf("running as root and no postgres user available: %w", err)
+		}
+		uid, _ := strconv.Atoi(u.Uid)
+		gid, _ := strconv.Atoi(u.Gid)
+		if err := os.Chown(base, uid, gid); err != nil {
+			os.RemoveAll(base)
+			return nil, fmt.Errorf("chown temp dir to postgres: %w", err)
+		}
+		cred = &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}
+	}
+
+	newCmd := func(name string, args ...string) *exec.Cmd {
+		cmd := exec.Command(name, args...)
+		cmd.Dir = base
+		if cred != nil {
+			cmd.SysProcAttr = &syscall.SysProcAttr{Credential: cred}
+		}
+		return cmd
+	}
+
+	// trust auth on a throwaway cluster; --no-sync/fsync=off trade durability we
+	// don't need for speed.
+	if out, err := newCmd(initdb, "-D", data, "-U", "postgres", "-A", "trust", "--no-sync", "-E", "UTF8").CombinedOutput(); err != nil {
+		os.RemoveAll(base)
+		return nil, fmt.Errorf("initdb: %v\n%s", err, out)
+	}
+
+	port, err := freePort()
+	if err != nil {
+		os.RemoveAll(base)
+		return nil, err
+	}
+
+	cmd := newCmd(postgresBin, "-D", data, "-p", strconv.Itoa(port), "-k", data,
+		"-h", "127.0.0.1", "-c", "fsync=off", "-c", "log_min_messages=fatal")
+	if err := cmd.Start(); err != nil {
+		os.RemoveAll(base)
+		return nil, fmt.Errorf("start postgres: %w", err)
+	}
+
+	dsn := fmt.Sprintf("postgres://postgres@127.0.0.1:%d/postgres?sslmode=disable", port)
+	pg := &embeddedPG{dsn: dsn, cmd: cmd, base: base}
+
+	deadline := time.Now().Add(25 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if db, err := sql.Open("postgres", dsn); err == nil {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			lastErr = db.PingContext(ctx)
+			cancel()
+			db.Close()
+			if lastErr == nil {
+				return pg, nil
+			}
+		} else {
+			lastErr = err
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	pg.stop()
+	return nil, fmt.Errorf("postgres did not become ready: %v", lastErr)
+}
+
+func (p *embeddedPG) stop() {
+	if p.cmd != nil && p.cmd.Process != nil {
+		_ = p.cmd.Process.Signal(syscall.SIGQUIT) // fast shutdown
+		done := make(chan struct{})
+		go func() { _, _ = p.cmd.Process.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			_ = p.cmd.Process.Kill()
+		}
+	}
+	os.RemoveAll(p.base)
+}

--- a/experimentation/e2e_test.go
+++ b/experimentation/e2e_test.go
@@ -1,0 +1,333 @@
+//go:build e2e
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"html/template"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestServer migrates and truncates the shared database, then serves the real
+// router over a local httptest server so tests exercise routing, auth, handlers,
+// the store and live SQL end to end.
+func newTestServer(t *testing.T) string {
+	t.Helper()
+	if testDSN == "" {
+		t.Skip("no test database (install postgres, or set TEST_DATABASE_URL)")
+	}
+	db, err := openDB(testDSN)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := migrate(ctx, db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	resetDB(t, db)
+
+	tmpl := template.Must(template.New("").Funcs(uiFuncs()).ParseFS(templatesFS, "web/templates/*.html"))
+	srv := &Server{store: &Store{db: db}, auth: authConfig{token: testAdminToken}, tmpl: tmpl}
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(func() { ts.Close(); db.Close() })
+	return ts.URL
+}
+
+func resetDB(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, err := db.Exec(`TRUNCATE projects, environments, sdk_keys, features,
+		feature_values, experiments, experiment_variants, experiment_events
+		RESTART IDENTITY CASCADE`)
+	if err != nil {
+		t.Fatalf("reset db: %v", err)
+	}
+}
+
+// ---- admin JSON API helpers ----
+
+func apiDo(t *testing.T, base, method, path string, body any) *http.Response {
+	t.Helper()
+	var r io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		r = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, base+path, r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+testAdminToken)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func mustStatus(t *testing.T, resp *http.Response, want int) {
+	t.Helper()
+	if resp.StatusCode != want {
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("%s %s: got %d, want %d\n%s", resp.Request.Method, resp.Request.URL.Path, resp.StatusCode, want, b)
+	}
+}
+
+func decode(t *testing.T, resp *http.Response, v any) {
+	t.Helper()
+	defer resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+		t.Fatalf("decode %s: %v", resp.Request.URL.Path, err)
+	}
+}
+
+// TestE2EAdminLifecycle drives the full create→use→update→delete lifecycle of
+// every resource through the admin JSON API and the public SDK endpoints.
+func TestE2EAdminLifecycle(t *testing.T) {
+	base := newTestServer(t)
+
+	// --- create project (auto-provisions production env + SDK key) ---
+	var created struct {
+		Project     Project     `json:"project"`
+		Environment Environment `json:"environment"`
+		SDKKey      string      `json:"sdkKey"`
+	}
+	resp := apiDo(t, base, "POST", "/api/admin/projects", map[string]string{"key": "acme", "name": "Acme"})
+	mustStatus(t, resp, http.StatusCreated)
+	decode(t, resp, &created)
+	if created.SDKKey == "" || created.Environment.Key != "production" {
+		t.Fatalf("unexpected create response: %+v", created)
+	}
+	prodKey := created.SDKKey
+
+	// --- get project: production env should be listed ---
+	var got struct {
+		Environments []Environment `json:"environments"`
+	}
+	resp = apiDo(t, base, "GET", "/api/admin/projects/acme", nil)
+	mustStatus(t, resp, http.StatusOK)
+	decode(t, resp, &got)
+	if len(got.Environments) != 1 || got.Environments[0].Key != "production" {
+		t.Fatalf("expected one production env, got %+v", got.Environments)
+	}
+
+	// --- create a second environment ---
+	resp = apiDo(t, base, "POST", "/api/admin/projects/acme/environments", map[string]string{"key": "staging", "name": "Staging"})
+	mustStatus(t, resp, http.StatusCreated)
+
+	// --- create a boolean feature and enable it at 100% in production ---
+	resp = apiDo(t, base, "POST", "/api/admin/projects/acme/features",
+		map[string]any{"key": "new_flow", "type": "boolean", "description": "the new flow", "default": false})
+	mustStatus(t, resp, http.StatusCreated)
+	resp = apiDo(t, base, "PUT", "/api/admin/projects/acme/features/new_flow/values/production",
+		map[string]any{"enabled": true, "value": true, "rollout": 100})
+	mustStatus(t, resp, http.StatusNoContent)
+
+	// --- create a running 2-way experiment ---
+	resp = apiDo(t, base, "POST", "/api/admin/projects/acme/experiments", map[string]any{
+		"key": "cta_test", "name": "CTA test", "status": "running", "metric": "signup", "control": "a",
+		"variants": []map[string]any{{"key": "a", "weight": 1}, {"key": "b", "weight": 1}},
+	})
+	mustStatus(t, resp, http.StatusCreated)
+
+	// --- SDK config: feature evaluates true, experiment assigns a variant ---
+	var cfg struct {
+		Project     string                     `json:"project"`
+		Environment string                     `json:"environment"`
+		Features    map[string]json.RawMessage `json:"features"`
+		Experiments map[string]struct {
+			Variant string `json:"variant"`
+		} `json:"experiments"`
+	}
+	resp = apiDo(t, base, "GET", "/api/v1/config?key="+prodKey+"&device=dev-1", nil)
+	mustStatus(t, resp, http.StatusOK)
+	decode(t, resp, &cfg)
+	if string(cfg.Features["new_flow"]) != "true" {
+		t.Fatalf("expected new_flow=true, got %s", cfg.Features["new_flow"])
+	}
+	if cfg.Experiments["cta_test"].Variant == "" {
+		t.Fatalf("expected a variant assignment, got %+v", cfg.Experiments)
+	}
+
+	// --- track exposure + conversion for a batch of devices ---
+	const devices = 12
+	for i := 0; i < devices; i++ {
+		device := "dev-" + string(rune('a'+i))
+		var dc struct {
+			Experiments map[string]struct {
+				Variant string `json:"variant"`
+			} `json:"experiments"`
+		}
+		resp = apiDo(t, base, "GET", "/api/v1/config?key="+prodKey+"&device="+device, nil)
+		mustStatus(t, resp, http.StatusOK)
+		decode(t, resp, &dc)
+		variant := dc.Experiments["cta_test"].Variant
+		for _, event := range []string{"exposure", "signup"} {
+			resp = apiDo(t, base, "POST", "/api/v1/track", map[string]string{
+				"key": prodKey, "device": device, "experiment": "cta_test", "variant": variant, "event": event,
+			})
+			mustStatus(t, resp, http.StatusNoContent)
+		}
+	}
+
+	// --- results: every device counted once as exposure and conversion ---
+	var results Results
+	resp = apiDo(t, base, "GET", "/api/admin/projects/acme/experiments/cta_test/results", nil)
+	mustStatus(t, resp, http.StatusOK)
+	decode(t, resp, &results)
+	totalExp, totalConv := 0, 0
+	for _, v := range results.Variants {
+		totalExp += v.Exposures
+		totalConv += v.Conversions
+	}
+	if totalExp != devices || totalConv != devices {
+		t.Fatalf("results exposures=%d conversions=%d, want %d each\n%+v", totalExp, totalConv, devices, results.Variants)
+	}
+
+	// --- updates ---
+	resp = apiDo(t, base, "PATCH", "/api/admin/projects/acme", map[string]string{"name": "Acme Inc"})
+	mustStatus(t, resp, http.StatusOK)
+	resp = apiDo(t, base, "PATCH", "/api/admin/projects/acme/environments/staging", map[string]string{"name": "Stage"})
+	mustStatus(t, resp, http.StatusOK)
+	resp = apiDo(t, base, "PATCH", "/api/admin/projects/acme/features/new_flow", map[string]any{"description": "updated", "default": false})
+	mustStatus(t, resp, http.StatusOK)
+	resp = apiDo(t, base, "PUT", "/api/admin/projects/acme/experiments/cta_test", map[string]any{
+		"name": "CTA", "status": "stopped", "metric": "signup", "control": "a",
+		"variants": []map[string]any{{"key": "a", "weight": 1}, {"key": "b", "weight": 1}},
+	})
+	mustStatus(t, resp, http.StatusOK)
+
+	// --- deletes (bottom-up), each verified ---
+	resp = apiDo(t, base, "DELETE", "/api/admin/projects/acme/features/new_flow/values/production", nil)
+	mustStatus(t, resp, http.StatusNoContent)
+	resp = apiDo(t, base, "DELETE", "/api/admin/projects/acme/experiments/cta_test", nil)
+	mustStatus(t, resp, http.StatusNoContent)
+	resp = apiDo(t, base, "GET", "/api/admin/projects/acme/experiments/cta_test/results", nil)
+	mustStatus(t, resp, http.StatusNotFound)
+	resp = apiDo(t, base, "DELETE", "/api/admin/projects/acme/features/new_flow", nil)
+	mustStatus(t, resp, http.StatusNoContent)
+	resp = apiDo(t, base, "DELETE", "/api/admin/projects/acme/environments/staging", nil)
+	mustStatus(t, resp, http.StatusNoContent)
+	resp = apiDo(t, base, "DELETE", "/api/admin/projects/acme", nil)
+	mustStatus(t, resp, http.StatusNoContent)
+	resp = apiDo(t, base, "GET", "/api/admin/projects/acme", nil)
+	mustStatus(t, resp, http.StatusNotFound)
+}
+
+// ---- UI form helpers (the path the browser uses) ----
+
+func uiClient() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+}
+
+func uiPost(t *testing.T, hc *http.Client, base, path string, form url.Values) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest("POST", base+path, strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Cookie", adminCookie+"="+testAdminToken)
+	resp, err := hc.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func uiGet(t *testing.T, base, path string) (int, string) {
+	t.Helper()
+	req, _ := http.NewRequest("GET", base+path, nil)
+	req.Header.Set("Cookie", adminCookie+"="+testAdminToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(b)
+}
+
+// TestE2EUICreateFlow covers the server-rendered form flow, including the bug
+// where bad input silently did nothing: invalid and duplicate keys must now
+// redirect back with a visible error, while valid input creates the resource.
+func TestE2EUICreateFlow(t *testing.T) {
+	base := newTestServer(t)
+	hc := uiClient()
+
+	// valid project create → redirect to the project page, then it renders.
+	resp := uiPost(t, hc, base, "/ui/projects", url.Values{"key": {"shopco"}, "name": {"Shop Co"}})
+	mustStatus(t, resp, http.StatusSeeOther)
+	if loc := resp.Header.Get("Location"); loc != "/ui/projects/shopco" {
+		t.Fatalf("valid create redirected to %q, want /ui/projects/shopco", loc)
+	}
+	if code, body := uiGet(t, base, "/ui/projects/shopco"); code != 200 || !strings.Contains(body, "shopco") {
+		t.Fatalf("project page: code=%d, contains key=%v", code, strings.Contains(body, "shopco"))
+	}
+
+	// invalid key → redirect carries an error, and nothing is created.
+	resp = uiPost(t, hc, base, "/ui/projects", url.Values{"key": {"Bad Key"}, "name": {"Bad"}})
+	mustStatus(t, resp, http.StatusSeeOther)
+	assertErrRedirect(t, resp, "/")
+	if code, _ := uiGet(t, base, "/ui/projects/Bad Key"); code != http.StatusNotFound {
+		t.Fatalf("invalid project should not exist, got code %d", code)
+	}
+
+	// duplicate key → redirect carries an error.
+	resp = uiPost(t, hc, base, "/ui/projects", url.Values{"key": {"shopco"}, "name": {"again"}})
+	mustStatus(t, resp, http.StatusSeeOther)
+	assertErrRedirect(t, resp, "/")
+
+	// the error actually renders as a banner on the target page.
+	if code, body := uiGet(t, base, "/?err=key+must+be+lowercase"); code != 200 ||
+		!strings.Contains(body, `class="banner"`) || !strings.Contains(body, "key must be lowercase") {
+		t.Fatalf("error banner not rendered: code=%d", code)
+	}
+
+	// invalid environment and feature keys surface errors too.
+	resp = uiPost(t, hc, base, "/ui/projects/shopco/environments", url.Values{"key": {"Bad Env"}})
+	mustStatus(t, resp, http.StatusSeeOther)
+	assertErrRedirect(t, resp, "/ui/projects/shopco")
+
+	resp = uiPost(t, hc, base, "/ui/projects/shopco/features", url.Values{"key": {"Bad Flag"}, "type": {"boolean"}})
+	mustStatus(t, resp, http.StatusSeeOther)
+	assertErrRedirect(t, resp, "/ui/projects/shopco")
+
+	// a clean environment create still works and redirects without an error.
+	resp = uiPost(t, hc, base, "/ui/projects/shopco/environments", url.Values{"key": {"staging"}, "name": {"Staging"}})
+	mustStatus(t, resp, http.StatusSeeOther)
+	if loc := resp.Header.Get("Location"); strings.Contains(loc, "err=") {
+		t.Fatalf("valid env create carried an error: %q", loc)
+	}
+}
+
+// assertErrRedirect fails unless the response redirects to path with an err query.
+func assertErrRedirect(t *testing.T, resp *http.Response, path string) {
+	t.Helper()
+	loc := resp.Header.Get("Location")
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("bad Location %q: %v", loc, err)
+	}
+	if u.Path != path || u.Query().Get("err") == "" {
+		t.Fatalf("expected redirect to %s with err=, got %q", path, loc)
+	}
+}

--- a/experimentation/ui.go
+++ b/experimentation/ui.go
@@ -8,6 +8,7 @@ import (
 	"html/template"
 	"log"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -45,9 +46,18 @@ func (s *Server) render(w http.ResponseWriter, name string, data map[string]any)
 	_, _ = buf.WriteTo(w)
 }
 
-func redirect(w http.ResponseWriter, r *http.Request, url string) {
-	http.Redirect(w, r, url, http.StatusSeeOther)
+func redirect(w http.ResponseWriter, r *http.Request, target string) {
+	http.Redirect(w, r, target, http.StatusSeeOther)
 }
+
+// redirectErr sends the user back to a page with a human-readable error in the
+// query string, which the page handler surfaces as a banner. Keeping the message
+// in the URL avoids any server-side flash/session state.
+func redirectErr(w http.ResponseWriter, r *http.Request, path, msg string) {
+	http.Redirect(w, r, path+"?err="+url.QueryEscape(msg), http.StatusSeeOther)
+}
+
+const badKeyMsg = "key must be lowercase letters, numbers, - or _ (e.g. my-project)"
 
 // valueFromForm builds a typed JSON value from a raw form string.
 func valueFromForm(typ, raw string) (json.RawMessage, error) {
@@ -139,7 +149,7 @@ func (s *Server) uiProjects(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	s.render(w, "projects", map[string]any{"Title": "Projects", "Projects": projects})
+	s.render(w, "projects", map[string]any{"Title": "Projects", "Projects": projects, "Error": r.URL.Query().Get("err")})
 }
 
 func (s *Server) uiCreateProject(w http.ResponseWriter, r *http.Request) {
@@ -147,7 +157,7 @@ func (s *Server) uiCreateProject(w http.ResponseWriter, r *http.Request) {
 	key := strings.TrimSpace(r.FormValue("key"))
 	name := strings.TrimSpace(r.FormValue("name"))
 	if !validKey(key) {
-		redirect(w, r, "/")
+		redirectErr(w, r, "/", badKeyMsg)
 		return
 	}
 	if name == "" {
@@ -155,7 +165,7 @@ func (s *Server) uiCreateProject(w http.ResponseWriter, r *http.Request) {
 	}
 	if _, _, _, err := s.provisionProject(r.Context(), key, name); err != nil {
 		log.Printf("ui create project: %v", err)
-		redirect(w, r, "/")
+		redirectErr(w, r, "/", "could not create project — key \""+key+"\" may already exist")
 		return
 	}
 	redirect(w, r, "/ui/projects/"+key)
@@ -207,7 +217,7 @@ func (s *Server) uiCreateEnv(w http.ResponseWriter, r *http.Request) {
 	key := strings.TrimSpace(r.FormValue("key"))
 	name := strings.TrimSpace(r.FormValue("name"))
 	if !validKey(key) {
-		redirect(w, r, "/ui/projects/"+p.Key)
+		redirectErr(w, r, "/ui/projects/"+p.Key, badKeyMsg)
 		return
 	}
 	if name == "" {
@@ -215,6 +225,8 @@ func (s *Server) uiCreateEnv(w http.ResponseWriter, r *http.Request) {
 	}
 	if _, _, err := s.provisionEnvironment(ctx, p.ID, key, name); err != nil {
 		log.Printf("ui create env: %v", err)
+		redirectErr(w, r, "/ui/projects/"+p.Key, "could not create environment — key \""+key+"\" may already exist")
+		return
 	}
 	redirect(w, r, "/ui/projects/"+p.Key)
 }
@@ -295,6 +307,7 @@ func (s *Server) uiProject(w http.ResponseWriter, r *http.Request) {
 		"SDKKeys":      keys,
 		"Features":     views,
 		"Experiments":  exps,
+		"Error":        r.URL.Query().Get("err"),
 	})
 }
 
@@ -308,8 +321,12 @@ func (s *Server) uiCreateFeature(w http.ResponseWriter, r *http.Request) {
 	_ = r.ParseForm()
 	key := strings.TrimSpace(r.FormValue("key"))
 	typ := r.FormValue("type")
-	if !validKey(key) || !validFeatureType(typ) {
-		redirect(w, r, "/ui/projects/"+p.Key)
+	if !validKey(key) {
+		redirectErr(w, r, "/ui/projects/"+p.Key, badKeyMsg)
+		return
+	}
+	if !validFeatureType(typ) {
+		redirectErr(w, r, "/ui/projects/"+p.Key, "type must be boolean, string, number or json")
 		return
 	}
 	def, verr := valueFromForm(typ, r.FormValue("default"))
@@ -318,6 +335,8 @@ func (s *Server) uiCreateFeature(w http.ResponseWriter, r *http.Request) {
 	}
 	if _, err := s.store.CreateFeature(ctx, p.ID, key, typ, strings.TrimSpace(r.FormValue("description")), def); err != nil {
 		log.Printf("ui create feature: %v", err)
+		redirectErr(w, r, "/ui/projects/"+p.Key, "could not create feature — key \""+key+"\" may already exist")
+		return
 	}
 	redirect(w, r, "/ui/projects/"+p.Key)
 }
@@ -337,7 +356,7 @@ func (s *Server) uiSetFeatureValue(w http.ResponseWriter, r *http.Request) {
 	_ = r.ParseForm()
 	env, err := s.store.GetEnvironment(ctx, p.ID, r.FormValue("environment"))
 	if err != nil {
-		redirect(w, r, "/ui/projects/"+p.Key)
+		redirectErr(w, r, "/ui/projects/"+p.Key, "unknown environment")
 		return
 	}
 	value, verr := valueFromForm(feat.Type, r.FormValue("value"))
@@ -442,17 +461,16 @@ func (s *Server) uiCreateExperiment(w http.ResponseWriter, r *http.Request) {
 		exp.Status = statusDraft
 	}
 	if !validKey(exp.Key) {
-		redirect(w, r, "/ui/projects/"+p.Key)
+		redirectErr(w, r, "/ui/projects/"+p.Key, badKeyMsg)
 		return
 	}
 	if msg, ok := validateExperiment(experimentBody{Name: exp.Name, Status: exp.Status, Metric: exp.Metric, Control: exp.Control, Variants: exp.Variants}); !ok {
-		log.Printf("ui create experiment: %s", msg)
-		redirect(w, r, "/ui/projects/"+p.Key)
+		redirectErr(w, r, "/ui/projects/"+p.Key, msg)
 		return
 	}
 	if _, err := s.store.CreateExperiment(ctx, exp); err != nil {
 		log.Printf("ui create experiment: %v", err)
-		redirect(w, r, "/ui/projects/"+p.Key)
+		redirectErr(w, r, "/ui/projects/"+p.Key, "could not create experiment — key \""+exp.Key+"\" may already exist")
 		return
 	}
 	redirect(w, r, "/ui/projects/"+p.Key+"/experiments/"+exp.Key)
@@ -480,8 +498,7 @@ func (s *Server) uiUpdateExperiment(w http.ResponseWriter, r *http.Request) {
 		exp.Status = statusDraft
 	}
 	if msg, ok := validateExperiment(experimentBody{Name: exp.Name, Status: exp.Status, Metric: exp.Metric, Control: exp.Control, Variants: exp.Variants}); !ok {
-		log.Printf("ui update experiment: %s", msg)
-		redirect(w, r, "/ui/projects/"+p.Key+"/experiments/"+exp.Key)
+		redirectErr(w, r, "/ui/projects/"+p.Key+"/experiments/"+exp.Key, msg)
 		return
 	}
 	if err := s.store.UpdateExperiment(ctx, exp); err != nil {
@@ -534,5 +551,6 @@ func (s *Server) uiExperiment(w http.ResponseWriter, r *http.Request) {
 		"Project":    p,
 		"Experiment": exp,
 		"Results":    buildResults(exp, exp.Metric, stats),
+		"Error":      r.URL.Query().Get("err"),
 	})
 }

--- a/experimentation/web/templates/layout.html
+++ b/experimentation/web/templates/layout.html
@@ -25,6 +25,7 @@
   .tag { font-size:11px; padding:1px 7px; border-radius:999px; border:1px solid var(--line); color:var(--muted); }
   .sig { font-size:12px; padding:2px 8px; border-radius:999px; background:rgba(74,222,128,.15); color:var(--good); }
   .err { color:var(--accent); }
+  .banner { background:rgba(255,138,92,.12); border:1px solid var(--accent); color:var(--accent); padding:10px 14px; border-radius:8px; margin-bottom:18px; font-size:14px; }
   input,select,textarea { background:#0c0d18; color:var(--text); border:1px solid var(--line); border-radius:7px; padding:7px 9px; font:inherit; }
   textarea { width:100%; font-family:ui-monospace,monospace; }
   button { background:#3a3d63; color:#fff; border:0; border-radius:7px; padding:8px 14px; font:inherit; cursor:pointer; }
@@ -45,6 +46,6 @@
   <a href="/" class="brand">⚙ Experimentation</a>
   <form method="post" action="/ui/logout"><button class="link">Sign out</button></form>
 </header>
-<main class="wrap">{{end}}
+<main class="wrap">{{if .Error}}<div class="banner">{{.Error}}</div>{{end}}{{end}}
 
 {{define "foot"}}</main></body></html>{{end}}


### PR DESCRIPTION
## What

Adds **edit and delete** across the experimentation admin UI and JSON API for every resource, fixes a silent-failure bug in the create forms, and adds a real end-to-end test suite.

You can now update **or** delete any resource directly on the UI:

| Resource | Create | Edit | Delete |
|---|---|---|---|
| Project | ✅ | ✅ rename | ✅ |
| Environment | ✅ (now in UI too) | ✅ rename | ✅ |
| Feature flag | ✅ | ✅ description + default | ✅ |
| Feature value (per env) | ✅ | ✅ | ✅ unset → default |
| Experiment | ✅ | ✅ | ✅ |

## Bug fix: "creating projects doesn't succeed"

The UI create handlers **silently redirected away** on invalid or duplicate input, so a bad key (uppercase, a space, empty) or a re-used key looked like a no-op with no feedback. Keys must match `^[a-z0-9][a-z0-9_-]{0,63}$`, so a display-style name like `Brand X` silently did nothing.

They now redirect back with a human-readable reason, rendered as a banner via a stateless `?err=` query param (no session store):
- `key must be lowercase letters, numbers, - or _ (e.g. my-project)`
- `could not create project — key "acme" may already exist`

Applied to project, environment, feature (key + type), and experiment creation, value-setting, and experiment updates. Keys/types stay immutable (changing them would invalidate stored values and URLs).

## How

- **store**: `UpdateProject`/`DeleteProject`, `UpdateEnvironment`/`DeleteEnvironment`, `UpdateFeature`/`DeleteFeature`/`DeleteFeatureValue`, `DeleteExperiment`. Deletes run in a transaction and also clear `experiment_events` (which have no foreign key), so reusing a project/experiment/environment key starts with clean results rather than inheriting stale events.
- **JSON API**: `PATCH`/`DELETE` on projects, environments and features; `DELETE` on feature values (unset) and experiments. Shared path-resolver helpers (`envFromPath`/`featureFromPath`/`experimentFromPath`); existing handlers refactored onto them.
- **UI**: rename/delete controls on the project and experiment pages, an environment-management section (create/rename/delete), per-flag edit + delete, and per-value unset. Destructive actions confirm first. Error banner on the shared layout.

## Tests

- **Unit**: render every page template with representative data and build the full mux, so template errors and bad/duplicate route patterns fail fast.
- **e2e** (`go test -tags e2e ./...`): a self-booting harness spins up a throwaway Postgres (locates `initdb`/`postgres`; drops to the `postgres` user when run as root; skips if unavailable; honours `TEST_DATABASE_URL`) and drives the real router over `httptest` through:
  - admin API: project → env → feature → value → experiment → SDK `config`+`track` → results → update → delete, each verified
  - UI forms: valid create redirects and renders; invalid + duplicate keys redirect back with a visible error and create nothing

All of `go test ./...`, `go test -tags e2e ./...`, `go vet` (both tags) and `gofmt` pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyUPX1BysycvR9n3pkojXn)_